### PR TITLE
Lock parent costmap mutex on updateBounds to avoid deadlock when clearing an area

### DIFF
--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -720,6 +720,10 @@ void SpatioTemporalVoxelLayer::updateBounds( \
     return;
   }
 
+  // Required because UpdateROSCostmap will also lock if AFTER we lock here voxel_grid_lock,
+  // and if clearArea is called in between, we will have a deadlock
+  boost::unique_lock<mutex_t> cm_lock(*getMutex());
+
   boost::recursive_mutex::scoped_lock lock(_voxel_grid_lock);
 
   // Steve's Note June 22, 2018


### PR DESCRIPTION
The deadlock sequence is
1. `updateBounds` locks `_voxel_grid_lock`
2. `clear_costmap` recovery locks costmap mutex
3. `clear_costmap` recovery calls `clearArea`
4. `clearArea` tries to lock `_voxel_grid_lock`     -->  locked waiting for `updateBounds` to release it
5. `updateBounds` tries to lock costmap mutex  -->  locked waiting for `clear_costmap` recovery to release it

The alternative is to remove [the lock at clearArea](https://github.com/rapyuta-robotics/spatio_temporal_voxel_layer/blob/c0f75443fdd6105230fc74decff337929eb47e56/src/spatio_temporal_voxel_layer.cpp#L823). I don't think it is needed

**Draft PR until we decide the best fix (and clear the TODOs added for info)**

To reproduce I use this simple script:
```
#!/usr/bin/env python

import rospy
import actionlib

from mbf_msgs.msg import RecoveryAction, RecoveryGoal, RecoveryResult

""" 
Continuously call recovery action.
"""

def call_recovery(seq, behavior):
    rospy.loginfo("Calling recovery behavior %s", behavior)
    recovery_goal = RecoveryGoal(concurrency_slot=seq, behavior=behavior)
    recovery_ac.send_goal(recovery_goal)


if __name__ == '__main__':
    rospy.init_node("spam_mbf_servers")

    recovery_ac = actionlib.SimpleActionClient("/move_base_flex/recovery", RecoveryAction)
    recovery_ac.wait_for_server(rospy.Duration(5))
    for i in range(1000):
        call_recovery(i, 'conservative_reset')
```
Note that I keep increasing `concurrency_slot`, so MBF calls recovery in parallel. In theory sequential calls should be enough, but I cannot make it fail that way.