### PR TITLE
Replace WallTime with Time

### DIFF
--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -168,7 +168,7 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
 /*****************************************************************************/
 {
   // sample time once for all clearing readings
-  const double cur_time = ros::WallTime::now().toSec();
+  const double cur_time = ros::Time::now().toSec();
 
   // check each point in the grid for inclusion in a frustum
   openvdb::DoubleGrid::ValueOnCIter cit_grid = _grid->cbeginValueOn();
@@ -307,7 +307,7 @@ void SpatioTemporalVoxelGrid::operator()(const \
   if (obs._marking)
   {
     float mark_range_2 = obs._obstacle_range_in_m * obs._obstacle_range_in_m;
-    const double cur_time = ros::WallTime::now().toSec();
+    const double cur_time = ros::Time::now().toSec();
 
     const sensor_msgs::PointCloud2& cloud = *(obs._cloud);
     sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");


### PR DESCRIPTION
## Description

Found this issue while replaying bag files, since even though I was replaying at x10 speed it was still taking N seconds of real time for the voxels to decay.

I think we should port this upstream as well after merging in our fork.